### PR TITLE
Update ARM test commands for Raspberry Pi Zero W and add test for Raspberry Pi 02w, 3 and 4

### DIFF
--- a/.github/workflows/ci-jobs.yml
+++ b/.github/workflows/ci-jobs.yml
@@ -119,5 +119,5 @@ jobs:
             base_image: https://dietpi.com/downloads/images/DietPi_RPi-ARMv8-Bullseye.7z
             cpu: cortex-a53
             commands: |
-                echo "ARM TEST - Raspberry Pi Zero W"
+                echo "ARM TEST - Raspberry Pi 02w, 3 and 4"
                 test `uname -m` = 'aarch64'

--- a/.github/workflows/ci-url.yml
+++ b/.github/workflows/ci-url.yml
@@ -1,7 +1,9 @@
 name: ci-url
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Publish"]
+    types:
+      - completed
 jobs:
   Lint:
     name: Lint
@@ -76,10 +78,21 @@ jobs:
           python -m pip install meson
           python -m pip install dbus-python
           pip install -r requirements.txt
-      - name: ARM build test    
+
+      - name: Test armv6l - Raspberry Pi Zero W 
         uses: pguyot/arm-runner-action@v2.5.2
         with:
-          base_image: https://github.com/crs-k/pwnagotchi/releases/download/${{ github.event.release.tag_name }}/pwnagotchi-v${{ github.event.release.tag_name }}.7z
+          base_image: https://github.com/crs-k/pwnagotchi/releases/download/${{  github.ref_name }}/pwnagotchi-rpi-bullseye-${{  github.ref_name }}-arm64.img.xz
           cpu: arm1176
           commands: |
-            echo "ARM TEST"
+              echo "ARM TEST - Raspberry Pi Zero W"
+              test `uname -m` = 'armv6l'
+
+      - name: Test 64-bit - Raspberry Pi 02w, 3 and 4
+        uses: pguyot/arm-runner-action@v2.5.2
+        with:
+          base_image: https://github.com/crs-k/pwnagotchi/releases/download/${{  github.ref_name }}/pwnagotchi-rpi-bullseye-${{  github.ref_name }}-arm64.img.xz
+          cpu: cortex-a53
+          commands: |
+              echo "ARM TEST - Raspberry Pi 02w, 3 and 4"
+              test `uname -m` = 'aarch64'


### PR DESCRIPTION
This pull request updates the ARM test commands to include tests for both Raspberry Pi Zero W and Raspberry Pi 02w, 3, and 4. The base images and CPUs are specified accordingly for each test. This ensures comprehensive testing for different ARM architectures.